### PR TITLE
docs: add dev instructions and ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+SalonManager/node_modules/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Salonmanager-mvp
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   cd SalonManager
+   npm install
+   ```
+2. Start the development server (serves API and client):
+   ```bash
+   npm run dev
+   ```
+3. Seed demo data (optional):
+   ```bash
+   curl -X POST http://localhost:5000/api/v1/seed
+   ```
+4. Open `http://localhost:5000` in your browser.
+
+The development server runs both the Express backend and the Vite-powered frontend on the same port.


### PR DESCRIPTION
## Summary
- add root .gitignore to exclude node_modules
- document how to run the development server and seed demo data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Argument of type 'string | null' is not assignable to parameter of type 'string | undefined')

------
https://chatgpt.com/codex/tasks/task_e_68acb8db599c8328921c90ca1b293307