### PR TITLE
fix: update stylist state and add test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+SalonManager/node_modules/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Salonmanager-mvp
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   cd SalonManager
+   npm install
+   ```
+2. Start the development server (serves API and client):
+   ```bash
+   npm run dev
+   ```
+3. Seed demo data (optional):
+   ```bash
+   curl -X POST http://localhost:5000/api/v1/seed
+   ```
+4. Open `http://localhost:5000` in your browser.
+
+The development server runs both the Express backend and the Vite-powered frontend on the same port.

--- a/SalonManager/client/src/components/booking-wizard.tsx
+++ b/SalonManager/client/src/components/booking-wizard.tsx
@@ -25,7 +25,7 @@ interface TimeSlot {
 export default function BookingWizard({ salon, isOpen, onClose }: BookingWizardProps) {
   const [currentStep, setCurrentStep] = useState(1);
   const [selectedService, setSelectedService] = useState<Service | null>(null);
-  const [selectedStylist, setSelectedStylist] = useState<string | null>(null);
+  const [selectedStylist, setSelectedStylist] = useState<string | undefined>(undefined);
   const [selectedDate, setSelectedDate] = useState('');
   const [selectedTime, setSelectedTime] = useState<TimeSlot | null>(null);
   const [note, setNote] = useState('');
@@ -99,7 +99,7 @@ export default function BookingWizard({ salon, isOpen, onClose }: BookingWizardP
   const handleClose = () => {
     setCurrentStep(1);
     setSelectedService(null);
-    setSelectedStylist(null);
+    setSelectedStylist(undefined);
     setSelectedDate('');
     setSelectedTime(null);
     setNote('');

--- a/SalonManager/package.json
+++ b/SalonManager/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "npm run check",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- align booking wizard stylist selection with optional type to satisfy TypeScript
- add `test` npm script to run the type checker

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68acb8db599c8328921c90ca1b293307